### PR TITLE
fix/improve(core/utils): Fix incorrect variables and indentation; return data in tables for consistency

### DIFF
--- a/modules/__core__/utils/client/module.lua
+++ b/modules/__core__/utils/client/module.lua
@@ -106,38 +106,28 @@ end
 
 -- Game
 module.game.requestModel = function(model, cb)
-
-  if type(model) == 'string' then
-    model = GetHashKey(model)
-  end
-
-  local interval
-
-  RequestModel(model)
-
-  interval = ESX.SetInterval(50, function()
-
-    if HasModelLoaded(model) then
-
-      ESX.ClearInterval(interval)
-
-      if cb ~= nil then
-        cb()
+  if type(model) == 'string' then model = GetHashKey(model) end
+  if IsModelValid(model) then
+    local interval
+    RequestModel(model)
+    interval = ESX.SetInterval(50, function()
+      if HasModelLoaded(model) then
+        ESX.ClearInterval(interval)
+        if cb ~= nil then
+          cb()
+        end
       end
-
-    end
-
-  end)
-
+    end)
+  else
+    print('Invalid/inexistent model => ' .. model)
+  end
 end
 
 module.game.requestAnimDict = function(model, cb)
   if type(model) == 'string' then
 
     local interval
-
     RequestAnimDict(model)
-
     interval = ESX.SetInterval(50, function()
       if HasAnimDictLoaded(model) then
         ESX.ClearInterval(interval)
@@ -170,51 +160,35 @@ module.game.teleport = function(entity, coords)
 end
 
 module.game.createObject = function(model, coords, cb)
-
-  if type(model) == 'string' then
-    model = GetHashKey(model)
-  end
+  if type(model) == 'string' then model = GetHashKey(model) end
 
   module.game.requestModel(model, function()
-
     local obj = CreateObject(model, coords.x, coords.y, coords.z, true, false, true)
     SetModelAsNoLongerNeeded(model)
 
     if cb ~= nil then
       cb(obj)
     end
-
   end)
-
 end
 
 module.game.createLocalObject = function(model, coords, cb)
-
-  if type(model) == 'string' then
-    model = GetHashKey(model)
-  end
+if type(model) == 'string' then model = GetHashKey(model) end
 
   module.game.requestModel(model, function()
-
     local obj = CreateObject(model, coords.x, coords.y, coords.z, false, false, true)
     SetModelAsNoLongerNeeded(model)
 
     if cb ~= nil then
       cb(obj)
     end
-
   end)
-
 end
 
 module.game.createVehicle = function(model, coords, heading, cb)
-
-  if type(model) == 'string' then
-    model = GetHashKey(model)
-  end
+  if type(model) == 'string' then model = GetHashKey(model) end
 
   module.game.requestModel(model, function()
-
     RequestCollisionAtCoord(coords.x, coords.y, coords.z)
 
     local vehicle   = CreateVehicle(model, coords.x, coords.y, coords.z, heading, true, false)
@@ -231,16 +205,11 @@ module.game.createVehicle = function(model, coords, heading, cb)
     if cb ~= nil then
       cb(vehicle)
     end
-
   end)
-
 end
 
 module.game.createLocalVehicle = function(model, coords, heading, cb)
-
-  if type(model) == 'string' then
-    model = GetHashKey(model)
-  end
+  if type(model) == 'string' then model = GetHashKey(model) end
 
   module.game.requestModel(model, function()
 

--- a/modules/__core__/utils/client/module.lua
+++ b/modules/__core__/utils/client/module.lua
@@ -293,126 +293,126 @@ end
 
 -- Enumerate entities
 module.game.getNearbyEntities = function(entities, coords, modelFilter, maxDistance, isPed)
-	local nearbyEntities = {}
-	coords = coords and vector3(coords.x, coords.y, coords.z) or GetEntityCoords(PlayerPedId())
-	for k, entity in pairs(entities) do
-		if not isPed or (isPed and not IsPedAPlayer(entity)) then
-			if not modelFilter or modelFilter[GetEntityModel(entity)] then
-				local entityCoords = GetEntityCoords(entity)
-				if not maxDistance or #(coords - entityCoords) <= maxDistance then
-					table.insert(nearbyEntities, {entity=entity, coords=entityCoords})
-				end
-			end
-		end
-	end
-	
-	return nearbyEntities
+  local nearbyEntities = {}
+  coords = coords and vector3(coords.x, coords.y, coords.z) or GetEntityCoords(PlayerPedId())
+  for k, entity in pairs(entities) do
+    if not isPed or (isPed and not IsPedAPlayer(entity)) then
+      if not modelFilter or modelFilter[GetEntityModel(entity)] then
+        local entityCoords = GetEntityCoords(entity)
+        local dist = #(coords - entityCoords)
+        if not maxDistance or dist <= maxDistance then
+          table.insert(nearbyEntities, {entity=entity, distance = dist, coords=entityCoords})
+        end
+      end
+    end
+  end
+  
+  return nearbyEntities
 end
 
-module.game.getClosestEntity = function(entities, coords, modelFilter, maxDistance, isPed)
-	local distance, closestEntity, closestCoords = maxDistance or 100
-	coords = coords and vector3(coords.x, coords.y, coords.z) or GetEntityCoords(PlayerPedId())
+module.game.getClosestEntity = function(entities, coords, modelFilter, distance, isPed)
+  local closestEntity = {}
+  coords = coords and vector3(coords.x, coords.y, coords.z) or GetEntityCoords(PlayerPedId())
+  for k, entity in pairs(entities) do
+    if not isPed or (isPed and not IsPedAPlayer(entity)) then
+      if not modelFilter or modelFilter[GetEntityModel(entity)] then
+        local entityCoords = GetEntityCoords(entity)
+        local dist = #(coords - entityCoords)
+        if not distance or dist <= distance then
+          distance = dist
+          closestEntity = {entity=entity, distance = dist, coords=entityCoords}
+        end
+      end
+    end
+  end
 
-	for k, entity in pairs(entities) do
-		if not isPed or (isPed and not IsPedAPlayer(entity)) then
-			if not modelFilter or modelFilter[GetEntityModel(entity)] then
-				local entityCoords = GetEntityCoords(entity)
-				local dist = #(coords - entityCoords)
-				if dist < distance then
-					closestEntity, distance, closestCoords = entity, dist, entityCoords
-				end
-			end
-		end
-	end
-	return closestEntity, distance, closestCoords
+  return closestEntity
 end
 
 module.game.getPlayers = function(includePlayer, closest, coords, distance)
-	local players, playerId = {}, PlayerId()
-	local distance = distance or 100
-	if type then coords = coords and vector3(coords.x, coords.y, coords.z) or GetEntityCoords(PlayerPedId()) end
-	
-	for k, player in pairs(GetActivePlayers()) do
-		if includePlayer or player ~= playerId then
-			if type == nil then
-				table.insert(players, {id = player, ped = GetPlayerPed(player)})
-			else
-				local entity = GetPlayerPed(player)
-				local entityCoords = GetEntityCoords(entity)
-				if not closest then
-					if #(coords - entityCoords) <= distance then
-						table.insert(players, {id = player, ped = entity, coords = entityCoords})
-					end
-				else
-					local dist = #(coords - entityCoords)
-					if dist <= players.dist or distance then
-						players = {id = player, ped = entity, coords = entityCoords, distance = dist}
-					end
-				end
-			end
-		end
-	end
-	
-	return players
-end
+  local players, playerId = {}, PlayerId()
+  local distance = distance or 100
+  if closest ~= nil then coords = coords and vector3(coords.x, coords.y, coords.z) or GetEntityCoords(PlayerPedId()) end
+  
+  for k, player in pairs(GetActivePlayers()) do
+    if includePlayer or player ~= playerId then
+      if closest == nil then
+        table.insert(players, {id = player, ped = GetPlayerPed(player)})
+      else
+        local entity = GetPlayerPed(player)
+        local entityCoords = GetEntityCoords(entity)
+        local dist = #(coords - entityCoords)
+        if dist <= distance then
+          if not closest then
+            table.insert(players, {id = player, ped = entity, coords = entityCoords, distance = dist})
+          else
+            distance = dist
+            players = {id = player, ped = entity, coords = entityCoords, distance = dist}
+          end
+        end
+      end
+    end
+  end
 
+  return players
+end
 
 -- Get entities in area
 module.game.getPlayersInArea = function(includePlayer, coords, maxDistance)
-	return module.game.getPlayers(includePlayer, false, coords, maxDistance) 
+  return module.game.getPlayers(includePlayer, false, coords, maxDistance) 
 end
 
 module.game.getPedsInArea = function(coords, maxDistance, modelFilter)
-	return module.game.getNearbyEntities(GetGamePool('CPed'), coords, modelFilter, true) 
+  return module.game.getNearbyEntities(GetGamePool('CPed'), coords, modelFilter, maxDistance, true) 
 end
 
 module.game.getObjectsInArea = function(coords, maxDistance, modelFilter)
-	return module.game.getNearbyEntities(GetGamePool('CObject'), coords, modelFilter, maxDistance) 
+  return module.game.getNearbyEntities(GetGamePool('CObject'), coords, modelFilter, maxDistance) 
 end
 
 module.game.getVehiclesInArea = function(coords, maxDistance, modelFilter)
-	return module.game.getNearbyEntities(GetGamePool('CVehicle'), coords, modelFilter, maxDistance) 
+  return module.game.getNearbyEntities(GetGamePool('CVehicle'), coords, modelFilter, maxDistance) 
 end
 
 module.game.getPickupsInArea = function(coords, maxDistance, modelFilter)  
-	return module.game.getNearbyEntities(GetGamePool('CPickup'), coords, modelFilter, maxDistance) 
+  return module.game.getNearbyEntities(GetGamePool('CPickup'), coords, modelFilter, maxDistance) 
 end
 
 -- Get closest entity of type
 module.game.getClosestPlayer = function(includePlayer, coords, maxDistance)
-	return module.game.getPlayers(includePlayer, true, coords, maxDistance) 
+  return module.game.getPlayers(includePlayer, true, coords, maxDistance) 
 end
 
 module.game.getClosestPed = function(coords, maxDistance, modelFilter)
-	return module.game.getClosestEntity(GetGamePool('CPed'), coords, modelFilter, maxDistance, true)
+  return module.game.getClosestEntity(GetGamePool('CPed'), coords, modelFilter, maxDistance, true)
 end
 
 module.game.getClosestObject = function(coords, maxDistance, modelFilter)
-	return module.game.getClosestEntity(GetGamePool('CObject'), coords, modelFilter, maxDistance)
+  return module.game.getClosestEntity(GetGamePool('CObject'), coords, modelFilter, maxDistance)
 end
 
 module.game.getClosestVehicle = function(coords, maxDistance, modelFilter)
-	return module.game.getClosestEntity(GetGamePool('CVehicle'), coords, modelFilter, maxDistance)
+  return module.game.getClosestEntity(GetGamePool('CVehicle'), coords, modelFilter, maxDistance)
 end
 
 module.game.getClosestPickup = function(coords, maxDistance, modelFilter)
-	return module.game.getClosestEntity(GetGamePool('CPickup'), coords, modelFilter, maxDistance)
+  return module.game.getClosestEntity(GetGamePool('CPickup'), coords, modelFilter, maxDistance)
 end
 
 module.game.getEntityFacing = function(type)  
-	local playerPed    = PlayerPedId()
-	local playerCoords = GetEntityCoords(playerPed)
-	local inDirection  = GetOffsetFromEntityInWorldCoords(playerPed, 0.0, 5.0, 0.0)
-	local rayHandle    = StartShapeTestRay(playerCoords, inDirection, 10, playerPed, 0)
-	local numRayHandle, hit, endCoords, surfaceNormal, entityHit = GetShapeTestResult(rayHandle)
-	
-	if hit == 1 then
-		local entityType = GetEntityType(entityHit)
-		entityType = entityType == type or entityType > 0
-		if entityHit > 0 then return entityHit end
-	end
+  local playerPed    = PlayerPedId()
+  local playerCoords = GetEntityCoords(playerPed)
+  local inDirection  = GetOffsetFromEntityInWorldCoords(playerPed, 0.0, 5.0, 0.0)
+  local rayHandle    = StartShapeTestRay(playerCoords, inDirection, 10, playerPed, 0)
+  local numRayHandle, hit, endCoords, surfaceNormal, entityHit = GetShapeTestResult(rayHandle)
+  
+  if hit == 1 then
+    local entityType = GetEntityType(entityHit)
+    entityType = entityType == type or entityType > 0
+    if entityHit > 0 then return entityHit end
+  end
 
-	return nil
+  return nil
 end
 
 module.game.getVehicleProperties = function(vehicle)

--- a/modules/__core__/utils/server/module.lua
+++ b/modules/__core__/utils/server/module.lua
@@ -21,7 +21,7 @@ module.game.createVehicle = function (model, coords, heading, cb)
     model = GetHashKey(model)
   end
 
-	local vehicle = Citizen.InvokeNative(CREATE_AUTOMOBILE, model, coords, heading)
+  local vehicle = Citizen.InvokeNative(CREATE_AUTOMOBILE, model, coords, heading)
 
   local interval
 
@@ -84,102 +84,100 @@ module.server.systemMessage = function(message)
 end
 
 -- Enumerate entities
-module.game.getNearbyEntities = function(entities, coords, modelFilter, maxDistance, isPed)
-	local nearbyEntities = {}
-	coords = type(coords) == 'number' and GetEntityCoords(GetPlayerPed(coords)) or vector3(coords.x, coords.y, coords.z)
-	for k, entity in pairs(entities) do
-		if not isPed or (isPed and not IsPedAPlayer(entity)) then
-			if not modelFilter or modelFilter[GetEntityModel(entity)] then
-				local entityCoords = GetEntityCoords(entity)
-				if not maxDistance or #(coords - entityCoords) <= maxDistance then
-					table.insert(nearbyEntities, {entity=entity, coords=entityCoords})
-				end
-			end
-		end
-	end
-	
-	return nearbyEntities
+module.game.getNearbyEntities = function(entities, coords, modelFilter, distance, isPed)
+  local nearbyEntities = {}
+  coords = type(coords) == 'number' and GetEntityCoords(GetPlayerPed(coords)) or vector3(coords.x, coords.y, coords.z)
+  for k, entity in pairs(entities) do
+    if not isPed or (isPed and not IsPedAPlayer(entity)) then
+      if not modelFilter or modelFilter[GetEntityModel(entity)] then
+        local entityCoords = GetEntityCoords(entity)
+        local dist = #(coords - entityCoords)
+        if not distance or dist <= distance then
+          table.insert(nearbyEntities, {entity=entity, distance = dist, coords=entityCoords})
+        end
+      end
+    end
+  end
+  
+  return nearbyEntities
 end
 
-module.game.getClosestEntity = function(entities, coords, modelFilter, maxDistance, isPed)
-	local distance, closestEntity, closestCoords = maxDistance or 100
-	coords = type(coords) == 'number' and GetEntityCoords(GetPlayerPed(coords)) or vector3(coords.x, coords.y, coords.z)
+module.game.getClosestEntity = function(entities, coords, modelFilter, distance, isPed)
+  local closestEntity = {}
+  coords = type(coords) == 'number' and GetEntityCoords(GetPlayerPed(coords)) or vector3(coords.x, coords.y, coords.z)
+  for k, entity in pairs(entities) do
+    if not isPed or (isPed and not IsPedAPlayer(entity)) then
+      if not modelFilter or modelFilter[GetEntityModel(entity)] then
+        local entityCoords = GetEntityCoords(entity)
+        local dist = #(coords - entityCoords)
+        if not distance or dist <= distance then
+          distance = dist
+          closestEntity = {entity=entity, distance = dist, coords=entityCoords}
+        end
+      end
+    end
+  end
 
-	for k, entity in pairs(entities) do
-		if not isPed or (isPed and not IsPedAPlayer(entity)) then
-			if not modelFilter or modelFilter[GetEntityModel(entity)] then
-				local entityCoords = GetEntityCoords(entity)
-				local dist = #(coords - entityCoords)
-				if dist < distance then
-					closestEntity, distance, closestCoords = entity, dist, entityCoords
-				end
-			end
-		end
-	end
-	return closestEntity, distance, closestCoords
+  return closestEntity
 end
 
-module.game.getPlayers = function(playerId, closest, coords, maxDistance)
-	local players = {}
-	local maxDistance = maxDistance or 100
-	local playerPed = playerId and GetPlayerPed(playerId)
-	if type then coords = type(coords) == 'number' and GetEntityCoords(GetPlayerPed(coords)) or vector3(coords.x, coords.y, coords.z) end
-	
-	for k, player in pairs(GetPlayers()) do
-		if player ~= playerId then
-			if type == nil then
-				table.insert(players, {id = player, ped = GetPlayerPed(player)})
-			else
-				local entity = GetPlayerPed(player)
-				local entityCoords = GetEntityCoords(entity)
-				if not closest then
-					if #(coords - entityCoords) <= maxDistance then
-						table.insert(players, {id = player, ped = entity, coords = entityCoords})
-					end
-				else
-					local dist = #(coords - entityCoords)
-					if dist <= players.dist or maxDistance then
-						players = {id = player, ped = entity, coords = entityCoords, distance = dist}
-					end
-				end
-			end
-		end
-	end
-	
-	return players
+module.game.getPlayers = function(playerId, closest, coords, distance)
+  local players, distance = {}, distance or 100
+  if closest ~= nil then coords = type(coords) == 'number' and GetEntityCoords(GetPlayerPed(playerId)) or vector3(coords.x, coords.y, coords.z) end
+  
+  for k, player in pairs(GetPlayers()) do
+    if player ~= playerId then
+      if closest == nil then
+        table.insert(players, {id = player, ped = GetPlayerPed(player)})
+      else
+        local entity = GetPlayerPed(player)
+        local entityCoords = GetEntityCoords(entity)
+        local dist = #(coords - entityCoords)
+        if #(coords - entityCoords) < distance then
+          if not closest then
+            table.insert(players, {id = player, ped = entity, coords = entityCoords, distance = dist})
+          else
+            distance = dist
+            players = {id = player, ped = entity, coords = entityCoords, distance = dist}
+          end
+        end
+      end
+    end
+  end
+  
+  return players
 end
-
 
 -- Get entities in area
 module.game.getPlayersInArea = function(playerId, coords, maxDistance)
-	return module.game.getPlayers(playerId, false, coords, maxDistance) 
+  return module.game.getPlayers(playerId, false, coords, maxDistance) 
 end
 
 module.game.getPedsInArea = function(coords, maxDistance, modelFilter)
-	return module.game.getNearbyEntities(GetAllPeds(), coords, modelFilter, true) 
+  return module.game.getNearbyEntities(GetAllPeds(), coords, modelFilter, maxDistance, true) 
 end
 
 module.game.getObjectsInArea = function(coords, maxDistance, modelFilter)
-	return module.game.getNearbyEntities(GetAllObjects(), coords, modelFilter, maxDistance) 
+  return module.game.getNearbyEntities(GetAllObjects(), coords, modelFilter, maxDistance) 
 end
 
 module.game.getVehiclesInArea = function(coords, maxDistance, modelFilter)
-	return module.game.getNearbyEntities(GetAllVehicles(), coords, modelFilter, maxDistance) 
+  return module.game.getNearbyEntities(GetAllVehicles(), coords, modelFilter, maxDistance) 
 end
 
 -- Get closest entity of type
 module.game.getClosestPlayer = function(playerId, coords, maxDistance)
-	return module.game.getPlayers(playerId, true, coords)
+  return module.game.getPlayers(playerId, true, coords)
 end
 
 module.game.getClosestPed = function(coords, maxDistance, modelFilter)
-	return module.game.getClosestEntity(GetAllPeds(), coords, modelFilter, maxDistance, true)
+  return module.game.getClosestEntity(GetAllPeds(), coords, modelFilter, maxDistance, true)
 end
 
 module.game.getClosestObject = function(coords, maxDistance, modelFilter)
-	return module.game.getClosestEntity(GetAllObjects(), coords, modelFilter, maxDistance)
+  return module.game.getClosestEntity(GetAllObjects(), coords, modelFilter, maxDistance)
 end
 
 module.game.getClosestVehicle = function(coords, maxDistance, modelFilter)
-	return module.game.getClosestEntity(GetAllVehicles(), coords, modelFilter, maxDistance)
+  return module.game.getClosestEntity(GetAllVehicles(), coords, modelFilter, maxDistance)
 end

--- a/modules/__core__/utils/server/module.lua
+++ b/modules/__core__/utils/server/module.lua
@@ -16,15 +16,9 @@ module.server = module.server or {}
 local CREATE_AUTOMOBILE = GetHashKey('CREATE_AUTOMOBILE')
 
 module.game.createVehicle = function (model, coords, heading, cb)
-
-  if type(model) == 'string' then
-    model = GetHashKey(model)
-  end
-
+  if type(model) == 'string' then model = GetHashKey(model) end
   local vehicle = Citizen.InvokeNative(CREATE_AUTOMOBILE, model, coords, heading)
-
   local interval
-
   interval = ESX.SetInterval(0, function()
     if DoesEntityExist(vehicle) then
       ESX.ClearInterval(interval)
@@ -39,35 +33,25 @@ module.game.createVehicle = function (model, coords, heading, cb)
 end
 
 module.game.createPed = function (model, coords, heading, cb)
-  if type(model) == 'string' then
-    modelHash = GetHashKey(model)
-
-    -- print("CreatePed: model = " .. model .. " | coords = " .. json.encode(coords) .. " | heading = " .. tostring(heading))
-    local ped = CreatePed(4, modelHash, coords, heading, true, false)
-
-    local interval
-
-    interval = ESX.SetInterval(0, function()
-      if DoesEntityExist(ped) then
-        ESX.ClearInterval(interval)
-      end
-    end)
-    
-    if ped and cb then
-      cb(ped)
-    else
-      cb(nil)
+  if type(model) == 'string' then modelHash = GetHashKey(model) end
+  -- print("CreatePed: model = " .. model .. " | coords = " .. json.encode(coords) .. " | heading = " .. tostring(heading))
+  local ped = CreatePed(4, modelHash, coords, heading, true, false)
+  local interval
+  interval = ESX.SetInterval(0, function()
+    if DoesEntityExist(ped) then
+      ESX.ClearInterval(interval)
     end
+  end)
+    
+  if ped and cb then
+    cb(ped)
   else
     cb(nil)
   end
 end
 
 module.game.createLocalVehicle = function(model, coords, heading, cb)
-  if type(model) == 'string' then
-    model = GetHashKey(model)
-  end
-
+  if type(model) == 'string' then model = GetHashKey(model) end
   local vehicle = CreateVehicle(model, coords.x, coords.y, coords.z, heading, false, false)
 
   if vehicle and cb then


### PR DESCRIPTION
Tested functionality and fixed some bugs and undesired behaviour.
I felt the output should be reliable, always a table containing the results; rather than returning 3 variables or a table containing 4 depending on whether it was an entity or player.

#### utils.game.getPlayersInArea(playerId, coords, maxDistance) and utils.game.getClosestPlayer(playerId, coords, maxDistance)
playerId to ignore
vector3 or playerId to center on
range to search

	utils.game.getPlayersInArea(2, 2, 50)
	{[1] = {id, ped, coords, distance}, [2] = {id, ped, coords, distance}}
	
	utils.game.getClosestPlayer(2, 2, 50)
	{id, ped, coords, distance}

#### utils.game.getPedsInArea(coords, maxDistance, modelFilter) and utils.game.getClosestPed(coords, maxDistance, modelFilter)
vector3 or playerId to center on
range to search
whitelisted models to locate

	utils.game.getPedsInArea(2, 50, {[2363753267]=true)
	{[1] = {entity, coords, distance}, [2] = {entity, coords, distance}}
	
	utils.game.getClosestPed(2, 50, {[2363753267]=true)
	{entity, coords, distance}

If there is no result it will still return an empty table so you can always rely on checking `result.distance` or `next(result)` before doing anything.


##### Edit:
Ensure requested models are valid and change some spacing on related functions.